### PR TITLE
Поддержка скриптов на Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "node --experimental-specifier-resolution=node --experimental-modules src/test.js",
     "test-ts": "node --experimental-specifier-resolution=node --experimental-modules dist/test.js",
-    "compare": "prettier --write raw; prettier --write dist;",
+    "compare": "prettier --write raw && prettier --write dist",
     "build": "tsc"
   },
   "author": "",


### PR DESCRIPTION
Замена неподдерживаемого в cmd.exe разделителя ; на &&, который поддерживается и в cmd.exe, и в bash
Благодаря данным изменениям, npm run compare корректно отрабатывает на Windows